### PR TITLE
#534265 問題解答画面（プレイ画面）における解答フォーム及び解答ボタンの実装

### DIFF
--- a/QuizGame/QuizGame/AnswerForm.Designer.cs
+++ b/QuizGame/QuizGame/AnswerForm.Designer.cs
@@ -87,13 +87,16 @@
             // 
             // UserAnswerLabel
             // 
+            this.UserAnswerLabel.Anchor = System.Windows.Forms.AnchorStyles.Right;
             this.UserAnswerLabel.BackColor = System.Drawing.Color.White;
             this.UserAnswerLabel.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.UserAnswerLabel.Font = new System.Drawing.Font("HGS創英角ﾎﾟｯﾌﾟ体", 15.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
             this.UserAnswerLabel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(55)))), ((int)(((byte)(55)))));
             this.UserAnswerLabel.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.UserAnswerLabel.Location = new System.Drawing.Point(20, 340);
+            this.UserAnswerLabel.Margin = new System.Windows.Forms.Padding(3, 1, 3, 1);
             this.UserAnswerLabel.Name = "UserAnswerLabel";
+            this.UserAnswerLabel.Padding = new System.Windows.Forms.Padding(10, 0, 10, 0);
             this.UserAnswerLabel.Size = new System.Drawing.Size(750, 50);
             this.UserAnswerLabel.TabIndex = 9;
             this.UserAnswerLabel.Text = "ユーザーの入力した答えを表示";

--- a/QuizGame/QuizGame/AnswerForm.cs
+++ b/QuizGame/QuizGame/AnswerForm.cs
@@ -9,9 +9,13 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace QuizGame {
+    /// <summary>
+    /// 解答及び正誤判定画面
+    /// </summary>
     public partial class AnswerForm : Form {
-        public AnswerForm() {
+        public AnswerForm(string vUserAnswerText) {
             InitializeComponent();
+            UserAnswerLabel.Text = vUserAnswerText;
         }
 
         private void CorrectButton_Click(object sender, EventArgs e) {

--- a/QuizGame/QuizGame/GamePlayForm.Designer.cs
+++ b/QuizGame/QuizGame/GamePlayForm.Designer.cs
@@ -72,6 +72,7 @@
             this.ScorePanel.Controls.Add(this.ScoreTitleLabel);
             this.ScorePanel.Cursor = System.Windows.Forms.Cursors.Default;
             this.ScorePanel.Font = new System.Drawing.Font("游ゴシック", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
+            this.ScorePanel.ForeColor = System.Drawing.Color.White;
             this.ScorePanel.Location = new System.Drawing.Point(642, 30);
             this.ScorePanel.Name = "ScorePanel";
             this.ScorePanel.Size = new System.Drawing.Size(110, 80);
@@ -83,10 +84,10 @@
             this.HintMessageLabel.Font = new System.Drawing.Font("HGS創英角ﾎﾟｯﾌﾟ体", 15.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
             this.HintMessageLabel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(55)))), ((int)(((byte)(55)))));
             this.HintMessageLabel.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.HintMessageLabel.Location = new System.Drawing.Point(98, 221);
+            this.HintMessageLabel.Location = new System.Drawing.Point(103, 224);
             this.HintMessageLabel.Name = "HintMessageLabel";
             this.HintMessageLabel.Padding = new System.Windows.Forms.Padding(0, 30, 0, 0);
-            this.HintMessageLabel.Size = new System.Drawing.Size(434, 63);
+            this.HintMessageLabel.Size = new System.Drawing.Size(459, 72);
             this.HintMessageLabel.TabIndex = 18;
             this.HintMessageLabel.Text = "困った時は僕をクリックしてみて！！！\r\n\r\n";
             this.HintMessageLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -94,7 +95,6 @@
             // QuestionLabel
             // 
             this.QuestionLabel.BackColor = System.Drawing.Color.White;
-            this.QuestionLabel.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.QuestionLabel.Font = new System.Drawing.Font("HGS創英角ﾎﾟｯﾌﾟ体", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
             this.QuestionLabel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(55)))), ((int)(((byte)(55)))));
             this.QuestionLabel.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -107,14 +107,18 @@
             // 
             // AnswerTextBox
             // 
+            this.AnswerTextBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.AnswerTextBox.BackColor = System.Drawing.Color.White;
             this.AnswerTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.AnswerTextBox.Font = new System.Drawing.Font("游ゴシック", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
-            this.AnswerTextBox.Location = new System.Drawing.Point(25, 339);
+            this.AnswerTextBox.Font = new System.Drawing.Font("HGS創英角ﾎﾟｯﾌﾟ体", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
+            this.AnswerTextBox.Location = new System.Drawing.Point(25, 340);
+            this.AnswerTextBox.Margin = new System.Windows.Forms.Padding(10, 5, 10, 5);
             this.AnswerTextBox.Multiline = true;
             this.AnswerTextBox.Name = "AnswerTextBox";
             this.AnswerTextBox.Size = new System.Drawing.Size(620, 50);
             this.AnswerTextBox.TabIndex = 19;
-            this.AnswerTextBox.Text = "ここに解答を入力してね";
+            this.AnswerTextBox.TabStop = false;
+            this.AnswerTextBox.Text = "ここに解答を入力してナル！";
             // 
             // AnswerButton
             // 
@@ -122,7 +126,7 @@
             this.AnswerButton.Cursor = System.Windows.Forms.Cursors.Hand;
             this.AnswerButton.Font = new System.Drawing.Font("HGS創英角ﾎﾟｯﾌﾟ体", 15.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
             this.AnswerButton.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.AnswerButton.Location = new System.Drawing.Point(652, 339);
+            this.AnswerButton.Location = new System.Drawing.Point(650, 340);
             this.AnswerButton.Name = "AnswerButton";
             this.AnswerButton.Size = new System.Drawing.Size(100, 50);
             this.AnswerButton.TabIndex = 20;
@@ -147,9 +151,9 @@
             // 
             this.HintBubblePicture.BackColor = System.Drawing.Color.Transparent;
             this.HintBubblePicture.Image = ((System.Drawing.Image)(resources.GetObject("HintBubblePicture.Image")));
-            this.HintBubblePicture.Location = new System.Drawing.Point(25, 195);
+            this.HintBubblePicture.Location = new System.Drawing.Point(75, 210);
             this.HintBubblePicture.Name = "HintBubblePicture";
-            this.HintBubblePicture.Size = new System.Drawing.Size(600, 130);
+            this.HintBubblePicture.Size = new System.Drawing.Size(550, 100);
             this.HintBubblePicture.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
             this.HintBubblePicture.TabIndex = 17;
             this.HintBubblePicture.TabStop = false;

--- a/QuizGame/QuizGame/GamePlayForm.cs
+++ b/QuizGame/QuizGame/GamePlayForm.cs
@@ -14,13 +14,15 @@ namespace QuizGame {
         public GamePlayForm() {
             InitializeComponent();
         }
-
         private void HintCharacterButton_Click(object sender, EventArgs e) {
             FormManager.ShowForm(new HintForm());
         }
-
         private void AnswerButton_Click(object sender, EventArgs e) {
-            FormManager.ShowForm(new AnswerForm());
+            if (string.IsNullOrEmpty(AnswerTextBox.Text.Trim())) {
+                AnswerTextBox.Text = "解答が入力されなかったナル！";
+            } else {
+                FormManager.ShowForm(new AnswerForm(AnswerTextBox.Text));
+            }
         }
     }
 }

--- a/QuizGame/QuizGame/RuleForm.Designer.cs
+++ b/QuizGame/QuizGame/RuleForm.Designer.cs
@@ -40,7 +40,7 @@
             this.RulesPanel.Controls.Add(this.RulesTitleLabel);
             this.RulesPanel.Cursor = System.Windows.Forms.Cursors.Default;
             this.RulesPanel.Font = new System.Drawing.Font("游ゴシック", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
-            this.RulesPanel.Location = new System.Drawing.Point(39, 27);
+            this.RulesPanel.Location = new System.Drawing.Point(40, 30);
             this.RulesPanel.Name = "RulesPanel";
             this.RulesPanel.Size = new System.Drawing.Size(700, 350);
             this.RulesPanel.TabIndex = 0;
@@ -50,11 +50,12 @@
             this.GameStartButton.Cursor = System.Windows.Forms.Cursors.Hand;
             this.GameStartButton.FlatAppearance.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(30)))), ((int)(((byte)(80)))), ((int)(((byte)(120)))));
             this.GameStartButton.FlatAppearance.BorderSize = 2;
-            this.GameStartButton.Font = new System.Drawing.Font("游ゴシック", 11.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
+            this.GameStartButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.GameStartButton.Font = new System.Drawing.Font("HGS創英角ﾎﾟｯﾌﾟ体", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
             this.GameStartButton.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(30)))), ((int)(((byte)(80)))), ((int)(((byte)(120)))));
-            this.GameStartButton.Location = new System.Drawing.Point(281, 303);
+            this.GameStartButton.Location = new System.Drawing.Point(280, 305);
             this.GameStartButton.Name = "GameStartButton";
-            this.GameStartButton.Size = new System.Drawing.Size(150, 25);
+            this.GameStartButton.Size = new System.Drawing.Size(150, 30);
             this.GameStartButton.TabIndex = 2;
             this.GameStartButton.Text = "ゲーム開始";
             this.GameStartButton.UseVisualStyleBackColor = true;
@@ -63,24 +64,25 @@
             // RulesDescriptionLabel
             // 
             this.RulesDescriptionLabel.Cursor = System.Windows.Forms.Cursors.Default;
-            this.RulesDescriptionLabel.Font = new System.Drawing.Font("游ゴシック", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
+            this.RulesDescriptionLabel.Font = new System.Drawing.Font("HGS創英角ﾎﾟｯﾌﾟ体", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
             this.RulesDescriptionLabel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(55)))), ((int)(((byte)(55)))));
             this.RulesDescriptionLabel.ImageAlign = System.Drawing.ContentAlignment.TopLeft;
-            this.RulesDescriptionLabel.Location = new System.Drawing.Point(0, 50);
+            this.RulesDescriptionLabel.Location = new System.Drawing.Point(-1, 50);
             this.RulesDescriptionLabel.Name = "RulesDescriptionLabel";
             this.RulesDescriptionLabel.Padding = new System.Windows.Forms.Padding(20, 10, 0, 0);
-            this.RulesDescriptionLabel.Size = new System.Drawing.Size(700, 298);
+            this.RulesDescriptionLabel.Size = new System.Drawing.Size(700, 250);
             this.RulesDescriptionLabel.TabIndex = 1;
             this.RulesDescriptionLabel.Text = resources.GetString("RulesDescriptionLabel.Text");
             // 
             // RulesTitleLabel
             // 
             this.RulesTitleLabel.Cursor = System.Windows.Forms.Cursors.Default;
-            this.RulesTitleLabel.Font = new System.Drawing.Font("游ゴシック", 11.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
+            this.RulesTitleLabel.Font = new System.Drawing.Font("HGS創英角ﾎﾟｯﾌﾟ体", 14.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
             this.RulesTitleLabel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(55)))), ((int)(((byte)(55)))));
             this.RulesTitleLabel.ImageAlign = System.Drawing.ContentAlignment.TopLeft;
-            this.RulesTitleLabel.Location = new System.Drawing.Point(0, 0);
+            this.RulesTitleLabel.Location = new System.Drawing.Point(-1, 0);
             this.RulesTitleLabel.Name = "RulesTitleLabel";
+            this.RulesTitleLabel.Padding = new System.Windows.Forms.Padding(0, 10, 0, 0);
             this.RulesTitleLabel.Size = new System.Drawing.Size(700, 40);
             this.RulesTitleLabel.TabIndex = 0;
             this.RulesTitleLabel.Text = "ルール説明";

--- a/QuizGame/QuizGame/RuleForm.cs
+++ b/QuizGame/QuizGame/RuleForm.cs
@@ -1,14 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace QuizGame {
+    /// <summary>
+    /// ルール画面
+    /// </summary>
     public partial class RuleForm : Form {
         public RuleForm() {
             InitializeComponent();

--- a/QuizGame/QuizGame/RuleForm.resx
+++ b/QuizGame/QuizGame/RuleForm.resx
@@ -118,7 +118,8 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="RulesDescriptionLabel.Text" xml:space="preserve">
-    <value>ようこそ、ときタクナルへ！このゲームでは、ヒント君と協力してクイズを解いていきます。
+    <value>
+ようこそ、ときタクナルへ！このゲームでは、ヒント君と協力してクイズを解いていきます。
 
 ゲームの流れ
 　全5問のクイズに挑戦します！各問題ごとに、あなたの答えを入力してください。

--- a/QuizGame/QuizGame/StartForm.Designer.cs
+++ b/QuizGame/QuizGame/StartForm.Designer.cs
@@ -32,8 +32,9 @@
             this.StartButton.BackColor = System.Drawing.Color.White;
             this.StartButton.Cursor = System.Windows.Forms.Cursors.Hand;
             this.StartButton.FlatAppearance.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(30)))), ((int)(((byte)(80)))), ((int)(((byte)(120)))));
+            this.StartButton.FlatAppearance.BorderSize = 2;
             this.StartButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.StartButton.Font = new System.Drawing.Font("游ゴシック Medium", 14.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.StartButton.Font = new System.Drawing.Font("HGS創英角ﾎﾟｯﾌﾟ体", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
             this.StartButton.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(30)))), ((int)(((byte)(80)))), ((int)(((byte)(120)))));
             this.StartButton.Location = new System.Drawing.Point(290, 250);
             this.StartButton.Name = "StartButton";
@@ -45,14 +46,14 @@
             // 
             // TitleLabel
             // 
-            this.TitleLabel.AutoSize = true;
             this.TitleLabel.Font = new System.Drawing.Font("HGS創英角ﾎﾟｯﾌﾟ体", 48F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.TitleLabel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(55)))), ((int)(((byte)(55)))));
-            this.TitleLabel.Location = new System.Drawing.Point(185, 135);
+            this.TitleLabel.Location = new System.Drawing.Point(-8, 135);
             this.TitleLabel.Name = "TitleLabel";
-            this.TitleLabel.Size = new System.Drawing.Size(411, 64);
+            this.TitleLabel.Size = new System.Drawing.Size(800, 64);
             this.TitleLabel.TabIndex = 1;
             this.TitleLabel.Text = "ときタクナル";
+            this.TitleLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // StartForm
             // 
@@ -66,7 +67,6 @@
             this.Name = "StartForm";
             this.Text = "ときタクナル";
             this.ResumeLayout(false);
-            this.PerformLayout();
 
         }
 

--- a/QuizGame/QuizGame/StartForm.cs
+++ b/QuizGame/QuizGame/StartForm.cs
@@ -1,14 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace QuizGame {
+    /// <summary>
+    /// スタート画面
+    /// </summary>
     public partial class StartForm : Form {
         public StartForm() {
             InitializeComponent();


### PR DESCRIPTION
「解答」ボタンを押した際に、解答及び正誤判定画面に遷移し、
ユーザーが入力した解答が解答及び正誤判定画面でそのまま表示されているように実装いたしました。

※空白または空で「解答」ボタンが押された際に、
　その旨をテキストボックスにメッセージとして出力するように実装いたしました。