### PR TITLE
#536317　Azure OpenAIのコンテンツフィルターエラー対応

### DIFF
--- a/QuizGame/QuizGame/AIDataModel.cs
+++ b/QuizGame/QuizGame/AIDataModel.cs
@@ -52,6 +52,37 @@ namespace QuizGame {
         /// </summary>
         [DataMember(Name = "choices")]
         public Choice[] Choices { get; set; }
+
+        /// <summary>
+        /// エラー情報（フィルタリングなどのエラーが発生した場合）
+        /// </summary>
+        [DataMember(Name = "error")]
+        public ErrorDetails Error { get; set; }
+    }
+
+
+    /// <summary>
+    /// エラー情報を格納するクラス
+    /// </summary>
+    [DataContract]
+    public class ErrorDetails {
+        /// <summary>
+        /// エラーメッセージ
+        /// </summary>
+        [DataMember(Name = "message")]
+        public string Message { get; set; }
+
+        /// <summary>
+        /// エラーコード
+        /// </summary>
+        [DataMember(Name = "code")]
+        public string Code { get; set; }
+
+        /// <summary>
+        /// エラー発生時のステータス
+        /// </summary>
+        [DataMember(Name = "status")]
+        public int Status { get; set; }
     }
 
     /// <summary>
@@ -65,5 +96,11 @@ namespace QuizGame {
         /// </summary>
         [DataMember(Name = "message")]
         public Message Message { get; set; }
+
+        /// <summary>
+        /// 応答の終了理由（"stop", "content_filter" など）
+        /// </summary>
+        [DataMember(Name = "finish_reason")]
+        public string FinishReason { get; set; }
     }
 }

--- a/QuizGame/QuizGame/AIQuestionProcessor.cs
+++ b/QuizGame/QuizGame/AIQuestionProcessor.cs
@@ -49,7 +49,6 @@ namespace QuizGame {
 
                 HttpResponseMessage wApiResponse = wApiClient.PostAsync(FApiUrl, wRequestContent).Result;
                 string wJsonResponse = wApiResponse.Content.ReadAsStringAsync().Result;
-
                 return DeserializeFromJson(wJsonResponse);
             }
         }
@@ -77,14 +76,17 @@ namespace QuizGame {
                 var wSerializer = new DataContractJsonSerializer(typeof(ResponseBody));
                 var wDeserializedResponse = (ResponseBody)wSerializer.ReadObject(wStream);
 
-                if (wDeserializedResponse == null) {
-                    return "エラー: APIレスポンスがnullです。";
+                // AOAIのコンテンツフィルタリングに該当する質問だった場合
+                if (wDeserializedResponse.Error != null && wDeserializedResponse.Error.Code == "content_filter") {
+                    return "その質問は良くない質問なんじゃないかな。" + Environment.NewLine + "ボクには答えられないよ。" + Environment.NewLine + "違う質問をしてみて！";
                 }
-                if (wDeserializedResponse.Choices == null || wDeserializedResponse.Choices.Length == 0) {
-                    return "エラー: AIの応答が無効です。（Choicesが空またはnull）";
-                }
-                if (wDeserializedResponse.Choices[0].Message == null || string.IsNullOrEmpty(wDeserializedResponse.Choices[0].Message.Content)) {
-                    return "エラー: AIからの回答が取得できませんでした。";
+
+                if (wDeserializedResponse == null ||
+                    wDeserializedResponse.Choices == null ||
+                    wDeserializedResponse.Choices.Length == 0 ||
+                    wDeserializedResponse.Choices[0].Message == null ||
+                    string.IsNullOrEmpty(wDeserializedResponse.Choices[0].Message.Content)) {
+                    return "ごめんね、うまく考えがまとまらなかったナル..." + Environment.NewLine + "他の質問をしてみて！";
                 }
                 return wDeserializedResponse.Choices[0].Message.Content;
             }

--- a/QuizGame/QuizGame/HintForm.Designer.cs
+++ b/QuizGame/QuizGame/HintForm.Designer.cs
@@ -44,7 +44,7 @@
             this.HintReplyLabel.Padding = new System.Windows.Forms.Padding(10, 20, 10, 20);
             this.HintReplyLabel.Size = new System.Drawing.Size(456, 206);
             this.HintReplyLabel.TabIndex = 23;
-            this.HintReplyLabel.Text = "ここに問題文を表示";
+            this.HintReplyLabel.Text = "手助けするよ！\r\n僕に質問してみて！\r\n";
             // 
             // QuestionBackButton
             // 
@@ -80,7 +80,7 @@
             this.QuestionTextBox.Name = "QuestionTextBox";
             this.QuestionTextBox.Size = new System.Drawing.Size(581, 70);
             this.QuestionTextBox.TabIndex = 25;
-            this.QuestionTextBox.Text = "日本の首都は？";
+            this.QuestionTextBox.Text = "ここに質問を入力してね！\r\n(例：世界で一番広い国はどこ？)\r\n";
             // 
             // QuestionSendButton
             // 

--- a/QuizGame/QuizGame/Program.cs
+++ b/QuizGame/QuizGame/Program.cs
@@ -14,8 +14,7 @@ namespace QuizGame {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
 
-            
-            Application.Run(new ResultForm());
+            Application.Run(new StartForm());
         }
     }
 }


### PR DESCRIPTION
・Azure OpenAIのコンテンツフィルターによって返答が拒否された際、その質問には答えられない旨のメッセージを表示するエラーハンドリングを追加しました。