### PR TITLE
#539188 テキストボックスに初期メッセージがある場合にカーソルでクリアして入力できる機能の実装

### DIFF
--- a/QuizGame/QuizGame/AnswerForm.cs
+++ b/QuizGame/QuizGame/AnswerForm.cs
@@ -14,7 +14,7 @@ namespace QuizGame {
         public AnswerForm(string vUserAnswerText) {
             InitializeComponent();
             LoadAnswer();
-            UserAnswerLabel.Text = vUserAnswerText;
+            UserAnswerLabel.Text = "あなたの答え：" + vUserAnswerText;
         }
 
         private void CorrectButton_Click(object sender, EventArgs e) {

--- a/QuizGame/QuizGame/CharacterMessageManager.cs
+++ b/QuizGame/QuizGame/CharacterMessageManager.cs
@@ -60,7 +60,7 @@ namespace QuizGame {
         /// <summary>
         /// 現在のヒント君メッセージを取得する
         /// </summary>
-        /// <returns>現在選択されている問題</returns>
+        /// <returns>現在選択されているメッセージ</returns>
         public static CharacterMessage GetCurrentHintkunMessage() {
             return FCurrentHintkunMessage;
         }

--- a/QuizGame/QuizGame/GamePlayForm.Designer.cs
+++ b/QuizGame/QuizGame/GamePlayForm.Designer.cs
@@ -112,6 +112,7 @@
             this.AnswerTextBox.BackColor = System.Drawing.Color.White;
             this.AnswerTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.AnswerTextBox.Font = new System.Drawing.Font("HGS創英角ﾎﾟｯﾌﾟ体", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
+            this.AnswerTextBox.ForeColor = System.Drawing.Color.DarkGray;
             this.AnswerTextBox.Location = new System.Drawing.Point(25, 345);
             this.AnswerTextBox.Margin = new System.Windows.Forms.Padding(10, 5, 10, 5);
             this.AnswerTextBox.Multiline = true;
@@ -119,7 +120,7 @@
             this.AnswerTextBox.Size = new System.Drawing.Size(620, 50);
             this.AnswerTextBox.TabIndex = 19;
             this.AnswerTextBox.TabStop = false;
-            this.AnswerTextBox.Text = "ここに解答を入力してナル！";
+            this.AnswerTextBox.Text = "ここに解答を入力してね！";
             // 
             // AnswerButton
             // 

--- a/QuizGame/QuizGame/GamePlayForm.cs
+++ b/QuizGame/QuizGame/GamePlayForm.cs
@@ -1,11 +1,18 @@
 ﻿using System;
+using System.Drawing;
+using System.Runtime.Remoting.Messaging;
 using System.Windows.Forms;
+using static System.Windows.Forms.VisualStyles.VisualStyleElement;
+using TextBox = System.Windows.Forms.TextBox;
 
 namespace QuizGame {
     /// <summary>
     /// 問題解答画面（プレイ画面）
     /// </summary>
     public partial class GamePlayForm : Form {
+        private readonly string FInitialAnswerMessage = "ここに解答を入力してね！";
+        private readonly string FEmptyAnswerMessage = "解答が入力されなかったよ！";
+
         /// <summary>
         /// 問題解答画面（プレイ画面）クラスのコンストラクタ
         /// </summary>
@@ -14,6 +21,8 @@ namespace QuizGame {
             LoadQuestion();
             UpdateScore();
             LoadHintkunMessage();
+            SetInitialMessage(AnswerTextBox, FInitialAnswerMessage);
+            AnswerTextBox.GotFocus += AnswerTextBox_GotFocus;
         }
         
         private void HintCharacterButton_Click(object sender, EventArgs e) {
@@ -22,13 +31,23 @@ namespace QuizGame {
         }
 
         private void AnswerButton_Click(object sender, EventArgs e) {
-            if (string.IsNullOrEmpty(AnswerTextBox.Text.Trim())) {
-                AnswerTextBox.Text = "解答が入力されなかったナル！";
+            if (string.IsNullOrEmpty(AnswerTextBox.Text.Trim()) || AnswerTextBox.Text == FInitialAnswerMessage || AnswerTextBox.Text == FEmptyAnswerMessage) {
+                SetInitialMessage(AnswerTextBox, FEmptyAnswerMessage);
                 SoundManager.Instance.PlayClickSound();
             } else {
                 SoundManager.Instance.PlayAnswerSound();
                 FormManager.ShowForm(new AnswerForm(AnswerTextBox.Text));
             }
+        }
+
+        /// <summary>
+        /// 任意のテキストボックスにメッセージを設定するメソッド（グレー色で設定）
+        /// </summary>
+        /// <param name="vTextBox">指定するテキストボックス</param>
+        /// <param name="vMessage">指定するメッセージ</param>
+        public static void SetInitialMessage(TextBox vTextBox, string vMessage) {
+            vTextBox.ForeColor = Color.DarkGray;
+            vTextBox.Text = vMessage;
         }
 
         /// <summary>
@@ -51,6 +70,18 @@ namespace QuizGame {
         /// </summary>
         private void UpdateScore() {
             ScoreValueLabel.Text = GameManager.GetFormattedScore();
+        }
+
+        /// <summary>
+        /// 初期メッセージが表示されている状態でテキストボックスにフォーカスされた場合、内容をクリアする
+        /// </summary>
+        /// <param name="sender">イベントを発生させたオブジェクト（未使用）</param>
+        /// <param name="e">イベントの引数（未使用）</param>
+        private void AnswerTextBox_GotFocus(object sender, EventArgs e) {
+            if (AnswerTextBox.Text == FInitialAnswerMessage || AnswerTextBox.Text == FEmptyAnswerMessage) {
+                AnswerTextBox.Clear();
+                AnswerTextBox.ForeColor = Color.FromArgb(60, 55, 55);
+            }
         }
     }
 }

--- a/QuizGame/QuizGame/HintForm.Designer.cs
+++ b/QuizGame/QuizGame/HintForm.Designer.cs
@@ -74,7 +74,8 @@
             // QuestionTextBox
             // 
             this.QuestionTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.QuestionTextBox.Font = new System.Drawing.Font("游ゴシック", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
+            this.QuestionTextBox.Font = new System.Drawing.Font("HGS創英角ﾎﾟｯﾌﾟ体", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
+            this.QuestionTextBox.ForeColor = System.Drawing.Color.DarkGray;
             this.QuestionTextBox.Location = new System.Drawing.Point(12, 329);
             this.QuestionTextBox.Multiline = true;
             this.QuestionTextBox.Name = "QuestionTextBox";

--- a/QuizGame/QuizGame/HintForm.cs
+++ b/QuizGame/QuizGame/HintForm.cs
@@ -1,12 +1,15 @@
 ﻿using System;
+using System.Drawing;
+using System.Runtime.Remoting.Messaging;
 using System.Windows.Forms;
+using static System.Windows.Forms.VisualStyles.VisualStyleElement;
 
 namespace QuizGame {
     /// <summary>
     /// ヒント画面
     /// </summary>
     public partial class HintForm : Form {
-
+        private readonly string FInitialQuestionMessage = "ここに質問を入力してね！" + Environment.NewLine + "(例：世界で一番広い国はどこ？)";
         private AIQuestionProcessor FAiProcessor;
 
         /// <summary>
@@ -15,16 +18,18 @@ namespace QuizGame {
         public HintForm() {
             InitializeComponent();
             FAiProcessor = new AIQuestionProcessor();
+            GamePlayForm.SetInitialMessage(QuestionTextBox, FInitialQuestionMessage);
+            QuestionTextBox.GotFocus += QuestionTextBox_GotFocus;
         }
 
         private void QuestionSendButton_Click(object vSender, EventArgs e) {
             SoundManager.Instance.PlayAnswerSound();
             string wUserInputMessage = QuestionTextBox.Text.Trim();
 
-            if (string.IsNullOrEmpty(wUserInputMessage)) {
+            if (string.IsNullOrEmpty(wUserInputMessage) || QuestionTextBox.Text == FInitialQuestionMessage) {
                 SoundManager.Instance.PlayClickSound();
                 HintReplyLabel.Text = "質問を入力してね！";
-                QuestionTextBox.Text = "ここに質問を入力してね！\r\n(例：世界で一番広い国はどこ？)\r\n";
+                GamePlayForm.SetInitialMessage(QuestionTextBox, FInitialQuestionMessage);
                 return;
             }
 
@@ -48,6 +53,18 @@ namespace QuizGame {
             SoundManager.Instance.PlayReturnSound();
             CharacterMessageManager.SetRandomHintkunMessage();
             FormManager.ShowForm(new GamePlayForm());
+        }
+
+        /// <summary>
+        /// 初期メッセージが表示されている状態でテキストボックスにフォーカスされた場合、内容をクリアする
+        /// </summary>
+        /// <param name="sender">イベントを発生させたオブジェクト（未使用）</param>
+        /// <param name="e">イベントの引数（未使用）</param>
+        private void QuestionTextBox_GotFocus(object sender, EventArgs e) {
+            if (QuestionTextBox.Text == FInitialQuestionMessage) {
+                QuestionTextBox.Clear();
+                QuestionTextBox.ForeColor = Color.FromArgb(60, 55, 55);
+            }
         }
     }
 }


### PR DESCRIPTION
・テキストボックスの初期メッセージにカーソルを当てた場合に、内容がクリアされて文字をそのまま入力できるようにする機能を実装しました。